### PR TITLE
Fix typo in Fortify.php

### DIFF
--- a/domains/Laravel/ComposerPackages/Packages/Fortify.php
+++ b/domains/Laravel/ComposerPackages/Packages/Fortify.php
@@ -28,7 +28,7 @@ class Fortify extends FirstPartyPackage implements ProvidesInstallationInstructi
         return new ClosurePostInstallTaskGroup(
             'Setup Laravel Fortify',
             fn () => [
-                "$artisan vendor:publish --no--interaction --provider=\"Laravel\Fortify\FortifyServiceProvider\"",
+                "$artisan vendor:publish --no-interaction --provider=\"Laravel\Fortify\FortifyServiceProvider\"",
                 "$artisan migrate",
             ],
         );


### PR DESCRIPTION
There was a script-breaking typo in the class `Fortify`.