### PR TITLE
Fix `sed` command usage in README.md

### DIFF
--- a/domains/InitializationScript/resources/templates/initialize.blade.php
+++ b/domains/InitializationScript/resources/templates/initialize.blade.php
@@ -44,7 +44,7 @@ rm "./{{ $initializationScript }}";
 # Remove TODO in readme
 TODOS_BEGIN=$(grep -Fn "Initializer for Laravel Todos START" README.md | cut -d ":" -f 1)
 TODOS_END=$(grep -Fn "Initializer for Laravel Todos END" README.md | cut -d ":" -f 1)
-sed $TODOS_BEGIN,${TODOS_END}d README.md | tee README.md > /dev/null
+sed -i "$TODOS_BEGIN,${TODOS_END}d" README.md
 
 echo '';
 <x-shell::banner title="Done!">


### PR DESCRIPTION
Before the `sed` command and `tee` was just emptying the README.md. That has now been fixed.