### PR TITLE
Wait for DB to be ready

### DIFF
--- a/domains/InitializationScript/InitializationScriptGenerator.php
+++ b/domains/InitializationScript/InitializationScriptGenerator.php
@@ -4,6 +4,7 @@ namespace Domains\InitializationScript;
 
 use Domains\CreateProjectForm\CreateProjectForm;
 use Domains\PostDownload\PostDownloadTaskGroupCreator;
+use Domains\PostDownload\PostDownloadTaskRenderer;
 use Domains\PostDownload\PostInitializationLinkResolver;
 use Illuminate\Contracts\View\Factory;
 
@@ -12,6 +13,7 @@ class InitializationScriptGenerator
     public function __construct(
         private Factory $view,
         private PostDownloadTaskGroupCreator $postDownloadTaskGroupCreator,
+        private PostDownloadTaskRenderer $taskRenderer,
         private PostInitializationLinkResolver $postInitializationLinkResolver,
     ) {
     }
@@ -19,6 +21,7 @@ class InitializationScriptGenerator
     public function render(CreateProjectForm $form): string
     {
         return $this->view->make('template::initialize', [
+            'taskRenderer' => $this->taskRenderer,
             'groups' => $this->postDownloadTaskGroupCreator->fromForm($form),
             'links' => $this->postInitializationLinkResolver->links($form),
             'initializationScript' => $this->scriptName(),

--- a/domains/InitializationScript/resources/templates/initialize.blade.php
+++ b/domains/InitializationScript/resources/templates/initialize.blade.php
@@ -2,6 +2,8 @@
 @php
     /** @var \Domains\PostDownload\PostDownloadTaskGroup[] $groups */
     /** @var \Domains\PostDownload\PostInitializationLink[] $links */
+    /** @var \Domains\PostDownload\PostDownloadTaskRenderer $taskRenderer */
+    /** @var string $initializationScript */
 @endphp
 set -e;
 
@@ -33,8 +35,8 @@ echo '';
 <x-shell::banner :title="$group->title()" />
 echo '';
 @foreach($group->tasks() as $task)
-echo {!! escapeshellarg(is_string($task) ? $task : $task->shell()) !!}
-{!! is_string($task) ? $task : $task->shell() !!};
+{!! $taskRenderer->announce($task) !!}
+{!! $taskRenderer->execute($task) !!}
 @endforeach
 
 @endforeach

--- a/domains/Laravel/ComposerPackages/Packages/Fortify.php
+++ b/domains/Laravel/ComposerPackages/Packages/Fortify.php
@@ -6,6 +6,7 @@ use Domains\Laravel\ComposerPackages\FirstPartyPackage;
 use Domains\Laravel\ComposerPackages\ProvidesInstallationInstructions;
 use Domains\PostDownload\ClosurePostInstallTaskGroup;
 use Domains\PostDownload\PostDownloadTaskGroup;
+use Domains\PostDownload\Tasks\WaitForDatabase;
 
 class Fortify extends FirstPartyPackage implements ProvidesInstallationInstructions
 {
@@ -29,6 +30,7 @@ class Fortify extends FirstPartyPackage implements ProvidesInstallationInstructi
             'Setup Laravel Fortify',
             fn () => [
                 "$artisan vendor:publish --no-interaction --provider=\"Laravel\Fortify\FortifyServiceProvider\"",
+                new WaitForDatabase($artisan),
                 "$artisan migrate",
             ],
         );

--- a/domains/Laravel/ComposerPackages/Packages/Passport.php
+++ b/domains/Laravel/ComposerPackages/Packages/Passport.php
@@ -6,6 +6,7 @@ use Domains\Laravel\ComposerPackages\FirstPartyPackage;
 use Domains\Laravel\ComposerPackages\ProvidesInstallationInstructions;
 use Domains\PostDownload\ClosurePostInstallTaskGroup;
 use Domains\PostDownload\PostDownloadTaskGroup;
+use Domains\PostDownload\Tasks\WaitForDatabase;
 use Domains\SourceCodeManipulation\Perl\AddTrait;
 
 class Passport extends FirstPartyPackage implements ProvidesInstallationInstructions
@@ -23,6 +24,7 @@ class Passport extends FirstPartyPackage implements ProvidesInstallationInstruct
         return new ClosurePostInstallTaskGroup(
             'Install Laravel Passport',
             fn () => [
+                new WaitForDatabase($artisan),
                 "$artisan migrate",
                 "$artisan passport:install",
                 AddTrait::toUserModel('\\Laravel\\Passport\\HasApiTokens'),

--- a/domains/Laravel/ComposerPackages/Packages/Telescope.php
+++ b/domains/Laravel/ComposerPackages/Packages/Telescope.php
@@ -6,6 +6,7 @@ use Domains\Laravel\ComposerPackages\FirstPartyPackage;
 use Domains\Laravel\ComposerPackages\ProvidesInstallationInstructions;
 use Domains\PostDownload\ClosurePostInstallTaskGroup;
 use Domains\PostDownload\PostDownloadTaskGroup;
+use Domains\PostDownload\Tasks\WaitForDatabase;
 
 class Telescope extends FirstPartyPackage implements ProvidesInstallationInstructions
 {
@@ -33,6 +34,7 @@ class Telescope extends FirstPartyPackage implements ProvidesInstallationInstruc
             'Setup Laravel Telescope',
             fn () => [
                 "$artisan telescope:install",
+                new WaitForDatabase($artisan),
                 "$artisan migrate",
             ],
         );

--- a/domains/PostDownload/PostDownloadTaskRenderer.php
+++ b/domains/PostDownload/PostDownloadTaskRenderer.php
@@ -13,7 +13,7 @@ class PostDownloadTaskRenderer
      */
     public function announce(PostDownloadTask|VerbosePostDownloadTask|string $task): string
     {
-        $description = match(true) {
+        $description = match (true) {
             $task instanceof VerbosePostDownloadTask => $task->shellDescription(),
             $task instanceof PostDownloadTask => $task->shell(),
             default => (string) $task,

--- a/domains/PostDownload/PostDownloadTaskRenderer.php
+++ b/domains/PostDownload/PostDownloadTaskRenderer.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Domains\PostDownload;
+
+/**
+ * Responsible for turning {@link PostDownloadTask}s into their respective shell
+ * code and announcing them to the user.
+ */
+class PostDownloadTaskRenderer
+{
+    /**
+     * Announce the task to the user.
+     */
+    public function announce(PostDownloadTask|VerbosePostDownloadTask|string $task): string
+    {
+        $description = match(true) {
+            $task instanceof VerbosePostDownloadTask => $task->shellDescription(),
+            $task instanceof PostDownloadTask => $task->shell(),
+            default => (string) $task,
+        };
+
+        return "echo {$this->escape($description)}";
+    }
+
+    private function escape(string $shell): string
+    {
+        return escapeshellarg($shell);
+    }
+
+    /**
+     * Return the shell string that should be executed.
+     */
+    public function execute(PostDownloadTask|string $task): string
+    {
+        return is_string($task) ? $task : $task->shell();
+    }
+}

--- a/domains/PostDownload/Tasks/MigrateDatabase.php
+++ b/domains/PostDownload/Tasks/MigrateDatabase.php
@@ -17,6 +17,9 @@ class MigrateDatabase implements PostDownloadTaskGroup
 
     public function tasks(): array
     {
-        return ["$this->artisan migrate"];
+        return [
+            new WaitForDatabase($this->artisan),
+            "$this->artisan migrate",
+        ];
     }
 }

--- a/domains/PostDownload/Tasks/WaitForDatabase.php
+++ b/domains/PostDownload/Tasks/WaitForDatabase.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Domains\PostDownload\Tasks;
+
+use Domains\PostDownload\PostDownloadTask;
+use Domains\PostDownload\VerbosePostDownloadTask;
+
+class WaitForDatabase implements PostDownloadTask, VerbosePostDownloadTask
+{
+    public function __construct(private string $artisan)
+    {
+    }
+
+    public function shellDescription(): string
+    {
+        return 'Waiting for database to accept connections...';
+    }
+
+    public function shell(): string
+    {
+        return <<<SHELL
+attempt=1;
+maxAttempts=5;
+sleepTime=5;
+until $this->artisan tinker --execute 'try { DB::statement("select true"); echo("DB ready"); } catch (Throwable \$e) { exit(1); }' | grep -q "DB ready" || [ \$attempt -eq \$maxAttempts ]; do
+    echo "Attempt \$attempt failed, retrying in \${sleepTime}s...";
+    ((attempt=attempt+1));
+    sleep \$sleepTime;
+done
+
+if [ "\$attempt" -eq "\$maxAttempts" ]; then
+    echo "Could not connect to database after \$attempt attempts! Aborting...";
+    exit 1;
+fi
+
+echo "Database ready!"
+SHELL;
+    }
+}

--- a/domains/PostDownload/VerbosePostDownloadTask.php
+++ b/domains/PostDownload/VerbosePostDownloadTask.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Domains\PostDownload;
+
+/**
+ * A {@link PostDownloadTask} where {@link PostDownloadTask::shell} is too
+ * verbose to display it to the user directly.
+ *
+ * For most tasks we show the user directly what gets executed. Sometimes this
+ * makes sense, sometimes it can be a bit verbose or distracting. If this is the
+ * case, implement this interface to display the contents of
+ * {@link VerbosePostDownloadTask::shellDescription()} instead of
+ * {@link PostDownloadTask::shell} when running the task.
+ */
+interface VerbosePostDownloadTask
+{
+    /**
+     * Short description of what the script is doing.
+     */
+    public function shellDescription(): string;
+}


### PR DESCRIPTION
Fixes #37 and also introduces a way to not always display every bash command to the user, while running `./initialize`. This is especially useful, if the shell commands do more than simple one-liners.